### PR TITLE
generalize http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,12 +859,14 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 name = "hiisi"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "bytes",
  "clap",
  "criterion",
  "env_logger",
  "futures",
+ "http 1.1.0",
  "http-body-util",
  "httparse",
  "libsql",

--- a/hiisi-server/Cargo.toml
+++ b/hiisi-server/Cargo.toml
@@ -15,11 +15,13 @@ name = "hiisid"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.86"
 base64 = "0.22.1"
 bytes = { version = "1" }
 clap = { version = "4.5", features = [ "derive", "env", "string" ] }
 env_logger = "0.11.5"
 futures = "0.3"
+http = "1.1.0"
 http-body-util = "0.1"
 httparse = "1.9.4"
 libsql = { git = "https://github.com/tursodatabase/libsql" }

--- a/hiisi-server/src/server.rs
+++ b/hiisi-server/src/server.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bytes::{Bytes, BytesMut};
 use socket2::{SockAddr, Socket};
 
@@ -36,41 +37,68 @@ fn on_accept<T>(
     io.recv(conn_sock, on_recv);
 }
 
+fn execute_request<T>(io: &mut IO<T>, buf: &[u8]) -> Result<Bytes> {
+    let ctx = io.context();
+    let req = parse_request(&buf)?;
+    let resp = io.block_on(executor::execute_client_req(ctx.manager.clone(), req))?;
+    Ok(proto::format_msg(&resp)?)
+}
+
 fn on_recv<T>(io: &mut IO<T>, sock: Rc<Socket>, buf: &[u8], n: usize) {
     if n == 0 {
         log::trace!("Client closed connection");
         io.close(sock);
         return;
     }
-    let ctx = io.context();
-    let req = parse_request(&buf[..n]);
-    let resp = io
-        .block_on(executor::execute_client_req(ctx.manager.clone(), req))
-        .unwrap();
-    let resp = format_response(resp);
+    let resp = match execute_request(io, &buf[..n]) {
+        Ok(resp) => format_response(resp, http::StatusCode::OK),
+        Err(x) => format_response(
+            format!("{}", x).into(),
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+        ),
+    };
+
     let n = resp.len();
     io.send(sock, resp.into(), n, on_send);
 }
 
-fn parse_request(buf: &[u8]) -> Request {
+fn parse_request(buf: &[u8]) -> Result<Request> {
     let mut headers = [httparse::EMPTY_HEADER; 64];
     let mut req = httparse::Request::new(&mut headers);
     let body_off = req.parse(buf).unwrap().unwrap();
     let database = "hello"; // TODO: take from request path
-    let req = proto::parse_client_req(&buf[body_off..]).unwrap();
-    Request {
+    let req = proto::parse_client_req(&buf[body_off..])?;
+    Ok(Request {
         database: database.to_owned(),
         req,
-    }
+    })
 }
 
-fn format_response(resp: proto::PipelineRespBody) -> Bytes {
-    let body = proto::format_msg(&resp).unwrap();
-    let header = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len());
-    let mut ret = BytesMut::new();
-    ret.extend_from_slice(header.as_bytes());
-    ret.extend_from_slice(&body);
-    ret.into()
+fn format_response(body: Bytes, status: http::StatusCode) -> Bytes {
+    let n = body.len();
+
+    let response = http::Response::builder().status(status).body(body).unwrap();
+
+    let mut response_bytes = BytesMut::new();
+    response_bytes.extend_from_slice(
+        format!(
+            "HTTP/1.1 {} {}\r\n",
+            response.status().as_u16(),
+            response.status().canonical_reason().unwrap_or("")
+        )
+        .as_bytes(),
+    );
+
+    for (key, value) in response.headers() {
+        response_bytes.extend_from_slice(
+            format!("{}: {}\r\n", key.as_str(), value.to_str().unwrap()).as_bytes(),
+        );
+    }
+
+    response_bytes.extend_from_slice(format!("Content-Length: {}\r\n\r\n", n).as_bytes());
+    response_bytes.extend_from_slice(response.into_body().as_ref());
+
+    response_bytes.into()
 }
 
 fn on_send<T>(io: &mut IO<T>, sock: Rc<Socket>, _n: usize) {


### PR DESCRIPTION
This allows us to process arbitrary headers and handle errors.

This is done in preparation for an admin server that will share this code, even if this code is extracted to a different file, but has value on itself.